### PR TITLE
✨ [Feature] - Resume, Job, Survey, Training, Profile 엔티티 초기 설계를 한다.

### DIFF
--- a/src/main/java/com/example/dgu/returnwork/domain/accident/Accident.java
+++ b/src/main/java/com/example/dgu/returnwork/domain/accident/Accident.java
@@ -1,5 +1,6 @@
 package com.example.dgu.returnwork.domain.accident;
 
+import com.example.dgu.returnwork.domain.BaseTimeEntity;
 import com.example.dgu.returnwork.domain.user.User;
 import jakarta.persistence.*;
 import lombok.*;
@@ -10,7 +11,7 @@ import lombok.*;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Builder
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-public class Accident {
+public class Accident extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "accident_id")

--- a/src/main/java/com/example/dgu/returnwork/domain/job/Job.java
+++ b/src/main/java/com/example/dgu/returnwork/domain/job/Job.java
@@ -1,0 +1,33 @@
+package com.example.dgu.returnwork.domain.job;
+
+import com.example.dgu.returnwork.domain.BaseTimeEntity;
+import com.example.dgu.returnwork.domain.mappingTable.ProfileJob;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Table(name = "job")
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class Job extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "job_id")
+    private Long id;
+
+    @Column(name = "name", nullable = false, length = 100)
+    private String name;
+
+    @Column(name = "code", nullable = false)
+    private Long code;
+
+    @OneToMany(mappedBy = "job", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
+    private List<ProfileJob> profileJobs = new ArrayList<>();
+}

--- a/src/main/java/com/example/dgu/returnwork/domain/mappingTable/ProfileJob.java
+++ b/src/main/java/com/example/dgu/returnwork/domain/mappingTable/ProfileJob.java
@@ -1,0 +1,27 @@
+package com.example.dgu.returnwork.domain.mappingTable;
+
+import com.example.dgu.returnwork.domain.BaseTimeEntity;
+import com.example.dgu.returnwork.domain.job.Job;
+import com.example.dgu.returnwork.domain.profile.Profile;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "profile_job")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class ProfileJob extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "profile_id")
+    private Profile profile;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "job_id")
+    private Job job;
+}

--- a/src/main/java/com/example/dgu/returnwork/domain/profile/Profile.java
+++ b/src/main/java/com/example/dgu/returnwork/domain/profile/Profile.java
@@ -1,0 +1,44 @@
+package com.example.dgu.returnwork.domain.profile;
+
+import com.example.dgu.returnwork.domain.BaseTimeEntity;
+import com.example.dgu.returnwork.domain.accident.Accident;
+import com.example.dgu.returnwork.domain.mappingTable.ProfileJob;
+import com.example.dgu.returnwork.domain.resume.Resume;
+import com.example.dgu.returnwork.domain.survey.Survey;
+import com.example.dgu.returnwork.domain.training.Training;
+import com.example.dgu.returnwork.domain.user.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "profile")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class Profile extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "profile_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "accident_id")
+    private Accident accident;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "survey_id")
+    private Survey survey;
+
+    @OneToMany(mappedBy = "profile", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
+    private List<ProfileJob> profileJobs = new ArrayList<>();
+}

--- a/src/main/java/com/example/dgu/returnwork/domain/resume/Resume.java
+++ b/src/main/java/com/example/dgu/returnwork/domain/resume/Resume.java
@@ -1,0 +1,47 @@
+package com.example.dgu.returnwork.domain.resume;
+
+import com.example.dgu.returnwork.domain.BaseTimeEntity;
+import com.example.dgu.returnwork.domain.job.Job;
+import com.example.dgu.returnwork.domain.user.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Table(name = "resume")
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class Resume extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "resume_id")
+    private Long id;
+
+    @Column(name = "capability", nullable = false, length = 50)
+    private String capability;
+
+    @Column(name = "career", columnDefinition = "text")
+    private String career;
+
+    @Column(name = "question", columnDefinition = "text")
+    private String question;
+
+    @Column(name = "prompt", columnDefinition = "text")
+    private String prompt;
+
+    @Column(name = "resume", columnDefinition = "text")
+    private String resume;
+
+    @Column(name = "word_limit", nullable = false)
+    private Integer wordLimit;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "job_id")
+    private Job job;
+}

--- a/src/main/java/com/example/dgu/returnwork/domain/survey/Survey.java
+++ b/src/main/java/com/example/dgu/returnwork/domain/survey/Survey.java
@@ -1,0 +1,59 @@
+package com.example.dgu.returnwork.domain.survey;
+
+import com.example.dgu.returnwork.domain.BaseTimeEntity;
+import com.example.dgu.returnwork.domain.user.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDate;
+
+@Table(name = "survey")
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class Survey extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "survey_id")
+    private Long id;
+
+    @Column(name = "name")
+    private LocalDate date;
+
+    @Column(name = "a1")
+    private Integer a1;
+
+    @Column(name = "a2")
+    private Integer a2;
+
+    @Column(name = "a3")
+    private Integer a3;
+
+    @Column(name = "a4")
+    private Integer a4;
+
+    @Column(name = "a5")
+    private Integer a5;
+
+    @Column(name = "a6")
+    private Integer a6;
+
+    @Column(name = "a7")
+    private Integer a7;
+
+    @Column(name = "a8")
+    private Integer a8;
+
+    @Column(name = "a9")
+    private Integer a9;
+
+    @Column(name = "a10")
+    private Integer a10;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+}

--- a/src/main/java/com/example/dgu/returnwork/domain/training/Training.java
+++ b/src/main/java/com/example/dgu/returnwork/domain/training/Training.java
@@ -1,0 +1,47 @@
+package com.example.dgu.returnwork.domain.training;
+
+import com.example.dgu.returnwork.domain.BaseTimeEntity;
+import com.example.dgu.returnwork.domain.region.Region;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDate;
+
+@Table(name = "training")
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class Training extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "training_id")
+    private Long id;
+
+    @Column(name = "title", nullable = false, length = 255)
+    private String title;
+
+    @Column(name = "inst_code", nullable = false)
+    private Long instCode;
+
+    @Column(name = "training_area_code")
+    private Long trainingAreaCode;
+
+    @Column(name = "start_date")
+    private LocalDate startDate;
+
+    @Column(name = "end_date")
+    private LocalDate endDate;
+
+    @Column(name = "course_fee")
+    private Integer courseFee;
+
+    @Column(name = "address", length = 255)
+    private String address;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "region_id")
+    private Region region;
+}


### PR DESCRIPTION
## 📝 요약
- Resume, Job, Survey, Training 엔티티 설계를 완료하고, 이를 하나로 관리하는 Profile 엔티티를 설계한다.

## 🔍 변경 사항
- 엔티티 설계 완료
- Profile 엔티티를 설계할 때, 이력에 Job이 여러 개 포함될 수 있고 Job 또한 여러 개의 이력에 속할 수 있음을 고려하여 다대다 매핑을 위해 ProfileJob라는 매핑테이블을 만들었습니다.


## 📋 체크리스트 
- [x] Resume 설계
- [x] Job 설계
- [x] Survey 설계
- [x] Training 설계
- [x] Profile 설계


## 🔗 관련 이슈
Closes #13
