### PR TITLE
✨ [Feature] - 패스워드 재확인 및 유저 삭제 API를 구현한다

### DIFF
--- a/src/main/java/com/example/dgu/returnwork/domain/auth/controller/AuthApi.java
+++ b/src/main/java/com/example/dgu/returnwork/domain/auth/controller/AuthApi.java
@@ -405,6 +405,62 @@ public interface AuthApi {
     public void logout();
 
 
+    @Operation(
+            summary = "비밀번호 재확인 API",
+            description = "비밀번호 재확인 API, user 삭제 또는 내정보 조회시 호출"
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "성공",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = com.example.dgu.returnwork.global.response.ApiResponse.class),
+                            examples = @ExampleObject(
+                                    name = "성공 응답",
+                                    value = """
+                        {
+                            "errorCode": null,
+                            "message": "OK",
+                            "result": null
+                        }
+                        """
+                            )
+                    )
+            ),
+            @ApiResponse(responseCode = "400", description = "패스워드가 일치하지 않는 경우",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = CustomErrorResponse.class),
+                            examples = @ExampleObject(
+                                    name = "패스워드 불일치",
+                                    value = """
+                        {
+                            "status" : 400,
+                            "errorCode" : "USER_002",
+                            "message" : "패스워드가 일치하지 않습니다."
+                        }
+                        """
+                            )
+                    )
+            ),
+            @ApiResponse(responseCode = "401", description = "유효하지 않은 토큰인 경우",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = CustomErrorResponse.class),
+                            examples = @ExampleObject(
+                                    name = "유효하지 않은 토큰",
+                                    value = """
+                        {
+                            "status" : 401,
+                            "errorCode" : "AUTH_001",
+                            "message" : "유효하지 않는 토큰입니다."
+                        }
+                        """
+                            )
+                    )
+            )
+    })
+    public void authPassword(
+            @Valid @RequestBody AuthPasswordRequestDto request,
+            @Parameter(hidden = true) @CurrentUser User user
+    );
+
 
 
 }

--- a/src/main/java/com/example/dgu/returnwork/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/example/dgu/returnwork/domain/auth/controller/AuthController.java
@@ -57,7 +57,7 @@ public class AuthController implements AuthApi {
     }
 
     @Override
-    @PostMapping("/user")
+    @PostMapping("/password")
     public void authPassword(AuthPasswordRequestDto request, User user) {
         authService.authPassword(request, user);
     }

--- a/src/main/java/com/example/dgu/returnwork/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/example/dgu/returnwork/domain/auth/controller/AuthController.java
@@ -6,6 +6,7 @@ import com.example.dgu.returnwork.domain.auth.service.AuthService;
 import com.example.dgu.returnwork.domain.auth.dto.response.GoogleLoginResponseDto;
 import com.example.dgu.returnwork.domain.auth.dto.response.LoginUserResponseDto;
 import com.example.dgu.returnwork.domain.user.User;
+import com.example.dgu.returnwork.global.annotation.CurrentUser;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -27,13 +28,13 @@ public class AuthController implements AuthApi {
 
     @Override
     @PostMapping("/login")
-    public LoginUserResponseDto login(@Valid @RequestBody LoginUserRequestDto request) {
+    public LoginUserResponseDto login(LoginUserRequestDto request) {
         return authService.login(request);
     }
 
     @Override
     @PostMapping("/google/login")
-    public GoogleLoginResponseDto googleLogin(@Valid @RequestBody GoogleLoginRequestDto request) {
+    public GoogleLoginResponseDto googleLogin(GoogleLoginRequestDto request) {
         return authService.googleLogin(request);
     }
 
@@ -53,5 +54,11 @@ public class AuthController implements AuthApi {
     @PostMapping("/logout")
     public void logout() {
         log.info("사용자 로그아웃 요청");
+    }
+
+    @Override
+    @PostMapping("/user")
+    public void authPassword(AuthPasswordRequestDto request, User user) {
+        authService.authPassword(request, user);
     }
 }

--- a/src/main/java/com/example/dgu/returnwork/domain/auth/dto/request/AuthPasswordRequestDto.java
+++ b/src/main/java/com/example/dgu/returnwork/domain/auth/dto/request/AuthPasswordRequestDto.java
@@ -1,0 +1,12 @@
+package com.example.dgu.returnwork.domain.auth.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+public record AuthPasswordRequestDto(
+
+        @NotBlank(message = "password를 입력해주세요")
+        @Schema(example = "ttkdd124@")
+        String password
+) {
+}

--- a/src/main/java/com/example/dgu/returnwork/domain/auth/dto/request/ReissueATKRequestDto.java
+++ b/src/main/java/com/example/dgu/returnwork/domain/auth/dto/request/ReissueATKRequestDto.java
@@ -5,6 +5,6 @@ import jakarta.validation.constraints.NotBlank;
 public record ReissueATKRequestDto(
 
         @NotBlank(message = "리프레시 토큰은 필수입니다.")
-        String RefreshToken
+        String refreshToken
 ) {
 }

--- a/src/main/java/com/example/dgu/returnwork/domain/auth/service/AuthService.java
+++ b/src/main/java/com/example/dgu/returnwork/domain/auth/service/AuthService.java
@@ -11,6 +11,7 @@ import com.example.dgu.returnwork.domain.user.User;
 import com.example.dgu.returnwork.domain.user.enums.Status;
 import com.example.dgu.returnwork.domain.user.exception.UserErrorCode;
 import com.example.dgu.returnwork.domain.user.repository.UserRepository;
+import com.example.dgu.returnwork.global.annotation.CurrentUser;
 import com.example.dgu.returnwork.global.auth.jwt.JwtUtil;
 import com.example.dgu.returnwork.global.auth.oauth.GoogleOAuthClient;
 import com.example.dgu.returnwork.global.auth.oauth.GoogleUserInfo;
@@ -20,7 +21,6 @@ import io.jsonwebtoken.Claims;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -78,7 +78,7 @@ public class AuthService {
         User user = userRepository.findByEmail(request.email())
                 .orElseThrow(() -> BaseException.type(UserErrorCode.USER_NOT_FOUND));
 
-        if (!passwordEncoder.matches(request.password(), user.getPassword())) {
+        if (!matchPassword(request.password(), user.getPassword())) {
             throw BaseException.type(UserErrorCode.INVALID_PASSWORD);
         }
 
@@ -119,7 +119,7 @@ public class AuthService {
     @Transactional
     public ReissueATKResponseDto reissueATK(ReissueATKRequestDto request) {
 
-        String refreshToken = request.RefreshToken();
+        String refreshToken = request.refreshToken();
 
         TokenValidationResult validationResult = jwtUtil.validateToken(refreshToken);
 
@@ -139,6 +139,12 @@ public class AuthService {
 
     }
 
+    @Transactional(readOnly = true)
+    public void authPassword(AuthPasswordRequestDto request, @CurrentUser User user) {
+        if (!matchPassword(request.password(), user.getPassword())) {
+            throw BaseException.type(UserErrorCode.INVALID_PASSWORD);
+        }
+    }
 
 
 
@@ -154,6 +160,10 @@ public class AuthService {
     // == password 암호화 == //
     private String encodePassword(String password) {
         return passwordEncoder.encode(password);
+    }
+
+    private boolean matchPassword(String password, String userPassword) {
+        return passwordEncoder.matches(password, userPassword);
     }
 
     // == google Login 메서드 == /

--- a/src/main/java/com/example/dgu/returnwork/domain/auth/service/AuthService.java
+++ b/src/main/java/com/example/dgu/returnwork/domain/auth/service/AuthService.java
@@ -82,6 +82,10 @@ public class AuthService {
             throw BaseException.type(UserErrorCode.INVALID_PASSWORD);
         }
 
+        if(user.getStatus().equals(Status.DELETED)){
+            user.restore();
+        }
+
         return generateLoginTokens(user);
     }
 
@@ -91,6 +95,11 @@ public class AuthService {
 
         GoogleUserInfo userInfo = googleOAuthClient.getUserInfo(request.accessToken());
         User user = findOrCreateUser(userInfo);
+
+
+        if(user.getStatus().equals(Status.DELETED)){
+            user.restore();
+        }
 
         return user.getStatus() == Status.PENDING 
                 ? GoogleLoginResponseDto.signUpNeeded(generateTempToken(user))

--- a/src/main/java/com/example/dgu/returnwork/domain/user/User.java
+++ b/src/main/java/com/example/dgu/returnwork/domain/user/User.java
@@ -1,15 +1,22 @@
 package com.example.dgu.returnwork.domain.user;
 
 import com.example.dgu.returnwork.domain.BaseTimeEntity;
+import com.example.dgu.returnwork.domain.accident.Accident;
+import com.example.dgu.returnwork.domain.profile.Profile;
 import com.example.dgu.returnwork.domain.region.Region;
+import com.example.dgu.returnwork.domain.resume.Resume;
+import com.example.dgu.returnwork.domain.survey.Survey;
 import com.example.dgu.returnwork.domain.user.enums.Provider;
 import com.example.dgu.returnwork.domain.user.enums.Role;
 import com.example.dgu.returnwork.domain.user.enums.Status;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 import lombok.*;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
 
@@ -18,7 +25,7 @@ import java.util.UUID;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@ToString(exclude = {"password"})
+@ToString(exclude = {"password", "profiles", "resumes", "accidents", "surveys"})
 @Builder
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class User extends BaseTimeEntity {
@@ -70,6 +77,27 @@ public class User extends BaseTimeEntity {
 
     @Column(name = "deleted_at")
     private LocalDateTime deletedAt;
+
+    // == 양방향 관계 + CASCADE 설정 == //
+    @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE, orphanRemoval = true, fetch = FetchType.LAZY)
+    @Builder.Default
+    @JsonIgnore
+    private List<Profile> profiles = new ArrayList<>();
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE, orphanRemoval = true, fetch = FetchType.LAZY)
+    @Builder.Default
+    @JsonIgnore
+    private List<Resume> resumes = new ArrayList<>();
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE, orphanRemoval = true, fetch = FetchType.LAZY)
+    @Builder.Default
+    @JsonIgnore
+    private List<Accident> accidents = new ArrayList<>();
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE, orphanRemoval = true, fetch = FetchType.LAZY)
+    @Builder.Default
+    @JsonIgnore
+    private List<Survey> surveys = new ArrayList<>();
 
 
     //== equals/hashCode 문제 == //

--- a/src/main/java/com/example/dgu/returnwork/domain/user/User.java
+++ b/src/main/java/com/example/dgu/returnwork/domain/user/User.java
@@ -9,6 +9,7 @@ import jakarta.persistence.*;
 import lombok.*;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.Objects;
 import java.util.UUID;
 
@@ -67,6 +68,9 @@ public class User extends BaseTimeEntity {
     @Builder.Default
     private Status status = Status.ACTIVE;
 
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
 
     //== equals/hashCode 문제 == //
     @Override
@@ -81,6 +85,17 @@ public class User extends BaseTimeEntity {
         return Objects.equals(email, user.email);
     }
 
+    // == delete 메서드 == //
+    public void softDelete(){
+        this.status = Status.DELETED;
+        this.deletedAt = LocalDateTime.now();
+    }
+
+    // === 복구 메서드 == //
+    public void restore(){
+        this.status = Status.ACTIVE;
+        this.deletedAt = null;
+    }
 
     // == update 메서드 == //
     public void update(String name, String phoneNumber, LocalDate birthDay, Region region, String career) {

--- a/src/main/java/com/example/dgu/returnwork/domain/user/controller/UserApi.java
+++ b/src/main/java/com/example/dgu/returnwork/domain/user/controller/UserApi.java
@@ -1,6 +1,8 @@
 package com.example.dgu.returnwork.domain.user.controller;
 
+import com.example.dgu.returnwork.domain.user.User;
 import com.example.dgu.returnwork.domain.user.dto.request.VerifyEmailRequestDto;
+import com.example.dgu.returnwork.global.annotation.CurrentUser;
 import com.example.dgu.returnwork.global.exception.CustomErrorResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -152,4 +154,61 @@ public interface UserApi {
             )
     })
     void verifyEmail(@RequestBody @Valid VerifyEmailRequestDto request);
+
+    @Operation(
+            summary = "사용자 삭제 API",
+            description = "soft delete 방식으로 user의 상태를 delete 상태로 바꿈"
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "성공",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = com.example.dgu.returnwork.global.response.ApiResponse.class),
+                            examples = @ExampleObject(
+                                    name = "성공 응답",
+                                    value = """
+                        {
+                            "errorCode": null,
+                            "message": "OK",
+                            "result": null
+                        }
+                        """
+                            )
+                    )
+            ),
+            @ApiResponse(responseCode = "400", description = "이미 삭제된 상태의 사용자인 경우",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = CustomErrorResponse.class),
+                            examples = @ExampleObject(
+                                    name = "이미 삭제된 사용자",
+                                    value = """
+                        {
+                            "status" : 400,
+                            "errorCode" : "USER_007",
+                            "message" : "이미 삭제된 상태의 사용자입니다."
+                        }
+                        """
+                            )
+                    )
+            ),
+            @ApiResponse(responseCode = "401", description = "유효하지 않은 토큰인 경우",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = CustomErrorResponse.class),
+                            examples = @ExampleObject(
+                                    name = "유효하지 않은 토큰",
+                                    value = """
+                        {
+                            "status" : 401,
+                            "errorCode" : "AUTH_001",
+                            "message" : "유효하지 않는 토큰입니다."
+                        }
+                        """
+                            )
+                    )
+            )
+    })
+    void deleteUser(
+            @Parameter(hidden = true) @CurrentUser User user
+    );
+
 }
+

--- a/src/main/java/com/example/dgu/returnwork/domain/user/controller/UserController.java
+++ b/src/main/java/com/example/dgu/returnwork/domain/user/controller/UserController.java
@@ -1,5 +1,6 @@
 package com.example.dgu.returnwork.domain.user.controller;
 
+import com.example.dgu.returnwork.domain.user.User;
 import com.example.dgu.returnwork.domain.user.dto.request.VerifyEmailRequestDto;
 import com.example.dgu.returnwork.domain.user.service.UserCommandService;
 import com.example.dgu.returnwork.domain.user.service.UserQueryService;
@@ -8,7 +9,7 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/auth")
+@RequestMapping("/api/user")
 public class UserController implements UserApi {
 
     private final UserCommandService userCommandService;
@@ -31,6 +32,13 @@ public class UserController implements UserApi {
     @Override
     @PostMapping("/send/code")
     public void verifyEmail(VerifyEmailRequestDto request) {
+
         userQueryService.verifyEmail(request);
+    }
+
+    @Override
+    @PatchMapping("/delete")
+    public void deleteUser(User user) {
+        userCommandService.deleteUser(user);
     }
 }

--- a/src/main/java/com/example/dgu/returnwork/domain/user/enums/Status.java
+++ b/src/main/java/com/example/dgu/returnwork/domain/user/enums/Status.java
@@ -1,5 +1,5 @@
 package com.example.dgu.returnwork.domain.user.enums;
 
 public enum Status {
-    ACTIVE,INACTIVE,DELETED,PENDING
+    ACTIVE,DELETED,PENDING
 }

--- a/src/main/java/com/example/dgu/returnwork/domain/user/exception/UserErrorCode.java
+++ b/src/main/java/com/example/dgu/returnwork/domain/user/exception/UserErrorCode.java
@@ -15,7 +15,8 @@ public enum UserErrorCode implements ErrorCode {
     ALREADY_EXIST_EMAIL(HttpStatus.BAD_REQUEST, "USER_003", "이미 가입된 이메일입니다."),
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER_004", "존재하지 않는 사용자입니다."),
     INVALID_EMAIL_CODE(HttpStatus.BAD_REQUEST, "USER_005", "일치하지 않는 이메일 코드입니다."),
-    EMAIL_CODE_ERROR(HttpStatus.BAD_REQUEST, "USER_006", "인증번호를 재요청해주세요.");
+    EMAIL_CODE_ERROR(HttpStatus.BAD_REQUEST, "USER_006", "인증번호를 재요청해주세요."),
+    ALREADY_DELETED_USER(HttpStatus.BAD_REQUEST, "USER_007", "이미 삭제된 상태의 사용자입니다");
 
     private final HttpStatus status;
     private final String errorCode;

--- a/src/main/java/com/example/dgu/returnwork/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/example/dgu/returnwork/domain/user/repository/UserRepository.java
@@ -2,8 +2,12 @@ package com.example.dgu.returnwork.domain.user.repository;
 
 
 import com.example.dgu.returnwork.domain.user.User;
+import com.example.dgu.returnwork.domain.user.enums.Status;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -12,4 +16,6 @@ public interface UserRepository extends JpaRepository<User, UUID> {
     Boolean existsByEmail(String email);
     Optional<User> findByEmail(String email);
     Optional<User> findByProviderId(String providerId);
+    List<User> findByStatusAndDeletedAtBefore(Status status, LocalDateTime deletedAt);
+
 }

--- a/src/main/java/com/example/dgu/returnwork/domain/user/scheduler/UserScheduler.java
+++ b/src/main/java/com/example/dgu/returnwork/domain/user/scheduler/UserScheduler.java
@@ -1,0 +1,38 @@
+package com.example.dgu.returnwork.domain.user.scheduler;
+
+import com.example.dgu.returnwork.domain.user.User;
+import com.example.dgu.returnwork.domain.user.enums.Status;
+import com.example.dgu.returnwork.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class UserScheduler {
+
+    private final UserRepository userRepository;
+
+    @Transactional
+    @Scheduled(cron = "0 0 2 * * *")
+    public void cleanupDeletedUser(){
+        LocalDateTime threeMonthsAgo = LocalDateTime.now().minusMonths(3);
+
+        List<User> userToDelete = userRepository.findByStatusAndDeletedAtBefore(Status.DELETED, threeMonthsAgo);
+
+        if(userToDelete.isEmpty()){
+            log.info("삭제할 사용자가 없습니다.");
+            return;
+        }
+
+        log.info("삭제 대상 사용자 수: {}", userToDelete.size());
+        userRepository.deleteAll(userToDelete);
+        log.info("사용자 삭제 완료: {} 명", userToDelete.size());
+    }
+}

--- a/src/main/java/com/example/dgu/returnwork/domain/user/service/UserCommandService.java
+++ b/src/main/java/com/example/dgu/returnwork/domain/user/service/UserCommandService.java
@@ -1,6 +1,10 @@
 package com.example.dgu.returnwork.domain.user.service;
 
+import com.example.dgu.returnwork.domain.user.User;
+import com.example.dgu.returnwork.domain.user.enums.Status;
+import com.example.dgu.returnwork.domain.user.exception.UserErrorCode;
 import com.example.dgu.returnwork.global.email.service.EmailService;
+import com.example.dgu.returnwork.global.exception.BaseException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -18,5 +22,12 @@ public class UserCommandService {
         emailService.sendEmailAuthentication(email);
     }
 
+    @Transactional
+    public void deleteUser(User user){
+        if(user.getStatus().equals(Status.DELETED)){
+            throw BaseException.type(UserErrorCode.ALREADY_DELETED_USER);
+        }
+        user.softDelete();
+    }
 
 }

--- a/src/main/java/com/example/dgu/returnwork/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/dgu/returnwork/global/config/SecurityConfig.java
@@ -42,9 +42,9 @@ public class SecurityConfig {
                 .authorizeHttpRequests(requests -> requests
                         .requestMatchers(
                                 "/api/auth/signup",
-                                "/api/auth/duplicate",
-                                "/api/auth/send",
-                                "/api/auth/send/code",
+                                "/api/user/duplicate",
+                                "/api/user/send",
+                                "/api/user/send/code",
                                 "/api/auth/login",
                                 "/api/auth/google/login",
                                 "/swagger-ui/**",


### PR DESCRIPTION
## 📝 요약
- 패스워드 재확인 및 유저 삭제 API 구현

## 🔍 변경 사항
User 엔티티에 연관관계 메서드 양방향 매핑 코드 추가 
cascade 옵션


## 📋 체크리스트
- [x] Schduler 설정
- [x] 로그인 시 delete status 확인 후 active로 바꿔주기
- [x] User 엔티티 수정


## 🔗 관련 이슈
Closes #41 
