### PR TITLE
♻️ [refactor] resume swagger 및 범위를 조정한다

### DIFF
--- a/src/main/java/com/example/dgu/returnwork/domain/resume/controller/ResumeApi.java
+++ b/src/main/java/com/example/dgu/returnwork/domain/resume/controller/ResumeApi.java
@@ -542,7 +542,7 @@ public interface ResumeApi {
                         {
                             "status" : 404,
                             "errorCode" : "RESUME_003",
-                            "message" : "해당 질문을 찾을 수 없습니다."
+                            "message" : "자소서 세부 문항을 찾을 수 없습니다."
                         }
                         """
                             )

--- a/src/main/java/com/example/dgu/returnwork/domain/resume/dto/request/CreateResumeQuestionRequestDto.java
+++ b/src/main/java/com/example/dgu/returnwork/domain/resume/dto/request/CreateResumeQuestionRequestDto.java
@@ -6,7 +6,7 @@ import jakarta.validation.constraints.NotNull;
 
 public record CreateResumeQuestionRequestDto(
     @NotNull
-    @Min(1) @Max(10)
+    @Min(1) @Max(5)
     Integer questionOrder
 ) {
 }

--- a/src/main/java/com/example/dgu/returnwork/domain/resume/dto/request/UpdateQuestionOrderRequestDto.java
+++ b/src/main/java/com/example/dgu/returnwork/domain/resume/dto/request/UpdateQuestionOrderRequestDto.java
@@ -1,11 +1,13 @@
 package com.example.dgu.returnwork.domain.resume.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 
 public record UpdateQuestionOrderRequestDto(
         @NotNull
         @Schema(example = "3")
+        @Min(1)
         Integer questionOrder
 ) {
 }


### PR DESCRIPTION
## 📝 요약
♻️ [refactor] resume swagger 및 범위를 조정한다

## 🔍 변경 사항


## 📋 체크리스트


## 🔗 관련 이슈
Closes #53 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 새로운 기능
  - 없음

- 버그 수정
  - 자소서 질문 순서 값의 검증을 보완했습니다: 최소값 1을 강제하고, 최대 허용값을 10에서 5로 축소했습니다. 유효 범위를 벗어난 요청은 검증 오류로 처리됩니다.

- 문서
  - 자소서 초안 항목 삭제 API의 404 예시 메시지를 “자소서 세부 문항을 찾을 수 없습니다.”로 업데이트하여 안내 문구를 명확히 했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->